### PR TITLE
fix: node CJS

### DIFF
--- a/src/runtime/lib/_getFiles.ts
+++ b/src/runtime/lib/_getFiles.ts
@@ -1,5 +1,4 @@
 import path from 'path'
-import {globby} from 'globby'
 import {_Observable} from './_observable'
 
 export function _getFiles(options: {
@@ -10,9 +9,11 @@ export function _getFiles(options: {
 
   return {
     subscribe(observer) {
-      globby(pattern, {cwd}).then((files) => {
-        observer.next(files.map((f) => path.resolve(cwd, f)))
-      })
+      import('globby').then(({globby}) =>
+        globby(pattern, {cwd}).then((files) => {
+          observer.next(files.map((f) => path.resolve(cwd, f)))
+        })
+      )
 
       return {
         unsubscribe() {


### PR DESCRIPTION
Since `globby` is ESM-only there's an error when running the CLI as reproduced here:
- https://github.com/sanity-io/icons/pull/7
- https://github.com/sanity-io/icons/pull/6

The error when running `workshop build`:
```bash
Error [ERR_REQUIRE_ESM]: require() of ES Module /vercel/path0/node_modules/.pnpm/globby@13.1.3/node_modules/globby/index.js from /vercel/path0/node_modules/.pnpm/@sanity+ui-workshop@1.1.2_cv7ht4if4mgyswwq2u7lgg7lju/node_modules/@sanity/ui-workshop/dist/runtime.cjs not supported.
```

Since our CJS mode is targeting Node v14 and later we can make use of dynamic imports to make the ESM-only dependency start working even in CJS node.

# This PR is blocked by [a `@sanity/pkg-utils` PR](https://github.com/sanity-io/pkg-utils/pull/28) and will moved out of Draft status once it's merged.